### PR TITLE
Fitur: Menambahkan gh action + ansible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
           script: |
             set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pbb-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"
+            nohup ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pbb-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}" > ~/ansible-update-pbb-rilis.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy PBB with Ansible
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to Production Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH using appleboy/ssh-action
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_PORT }}
+          script: |
+            cd /opt/ansible
+            ansible-playbook -v -i inventories/production/inventory.yml playbooks/deploy-pbb.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy PBB Rilis with Ansible
 
 on:
-  pull_request:
-    branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy:
     # rilis dari branch 'main' & bukan prerelease
-    # if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
+    if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
     name: Deploy PBB Rilis to Production Server
     runs-on: ubuntu-latest
 
@@ -32,4 +32,4 @@ jobs:
           script: |
             set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pbb-rilis.yml
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pbb-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,21 @@
-name: Deploy PBB with Ansible
+name: Deploy PBB Rilis with Ansible
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pbb-rilis
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    name: Deploy to Production Server
+    # rilis dari branch 'main' & bukan prerelease
+    # if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
+    name: Deploy PBB Rilis to Production Server
     runs-on: ubuntu-latest
 
     steps:
@@ -14,12 +23,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Deploy via SSH using appleboy/ssh-action
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
           username: ${{ secrets.CICD_SERVER_USER }}
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_PORT }}
           script: |
-            cd /opt/ansible
-            ansible-playbook -v -i inventories/production/inventory.yml playbooks/deploy-pbb.yml
+            set -euo pipefail
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-pbb-rilis.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy PBB with Ansible
 
 on:
-  pull_request:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_siappakai.yml
+++ b/.github/workflows/deploy_siappakai.yml
@@ -1,0 +1,35 @@
+name: Deploy SiapPakai Update PBB with Ansible
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pbb-rilis
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # rilis dari branch 'main' & bukan prerelease
+    # if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
+    name: Deploy SiapPakai Update PBB ke Server SiapPakai
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH using appleboy/ssh-action
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_PORT }}
+          script: |
+            set -euo pipefail
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-pbb.yml --vault-password-file ~/.vault_pass.txt

--- a/.github/workflows/deploy_siappakai.yml
+++ b/.github/workflows/deploy_siappakai.yml
@@ -1,20 +1,20 @@
 name: Deploy SiapPakai Update PBB with Ansible
 
 on:
-  pull_request:
-    branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: read
 
 concurrency:
-  group: deploy-pbb-rilis
+  group: deploy-pbb-siappakai-rilis
   cancel-in-progress: true
 
 jobs:
   deploy:
     # rilis dari branch 'main' & bukan prerelease
-    # if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
+    if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
     name: Deploy SiapPakai Update PBB ke Server SiapPakai
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_siappakai.yml
+++ b/.github/workflows/deploy_siappakai.yml
@@ -32,4 +32,4 @@ jobs:
           script: |
             set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-pbb.yml --vault-password-file ~/.vault_pass.txt
+            nohup ansible-playbook -i inventories/production/inventory.yml playbooks/siappakai-update-pbb.yml --vault-password-file ~/.vault_pass.txt > ~/ansible-update-api-rilis.log 2>&1 &


### PR DESCRIPTION
## Deskripsi
Menambahkan fitur github action deploy otomatis via ansible

Ada 2 workflow:
- deploy aplikasi
- deploy siappakai pbb

**Deploy rilis**
- Deploy ke branch `main` dengan event rilis publish dan bukan prerelease
- Akan checkout ke `tag` rilis
<img width="1035" height="543" alt="image" src="https://github.com/user-attachments/assets/4545fd75-8fc8-4b61-96ea-1296e298c88d" />

---

**Deploy siappakai**
- Hanya jalankan perintah: `php artisan siappakai:update-pbb`
- Untuk hosts siappakai
<img width="1587" height="906" alt="image" src="https://github.com/user-attachments/assets/5fddb2fd-a6be-4675-bd0d-bcc298531d39" />


Untuk issue:
- https://github.com/OpenSID/DukunganTeknis/issues/363
- https://github.com/OpenSID/DukunganTeknis/issues/441

